### PR TITLE
Avoid loading entities for projections

### DIFF
--- a/quarkus-otel-db-perf/src/main/java/com/brunobat/rest/LegumeRepository.java
+++ b/quarkus-otel-db-perf/src/main/java/com/brunobat/rest/LegumeRepository.java
@@ -16,7 +16,7 @@ public class LegumeRepository implements PanacheRepository<Legume> {
     EntityManager manager;
 
     public Stream<LegumeItem> listLegumes(int pageIndex) {
-        return find("SELECT h FROM Legume h")
+        return find("FROM Legume h")
 //                .withHint("org.hibernate.cacheable", "true")
                 .project(LegumeItem.class)
                 .page(pageIndex, 16).stream();

--- a/quarkus-otel-db-perf/src/main/java/com/brunobat/rest/data/LegumeItem.java
+++ b/quarkus-otel-db-perf/src/main/java/com/brunobat/rest/data/LegumeItem.java
@@ -1,6 +1,5 @@
 package com.brunobat.rest.data;
 
-import com.brunobat.rest.model.Legume;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.validation.constraints.NotBlank;
 
@@ -17,12 +16,6 @@ public class LegumeItem {
         this.id = id;
         this.name = name;
         this.description = description;
-    }
-
-    public LegumeItem(Legume legume) {
-        this.id = legume.getId();
-        this.name = legume.getName();
-        this.description = legume.getDescription();
     }
 
     public LegumeItem() {


### PR DESCRIPTION
This should remove the main reason for allocations by Hibernate.

Previously:

* By stating `SELECT h` in the query `SELECT h FROM Legume h`, we were explicitly requesting the query to return entity instances.
* By calling `.project(LegumeItem.class)` we were asking Hibernate to project query results to a `LegumeItem`, and since query results are entity instances we were asking Hibernate to call `new LegumeItem(legumeEntityInstance)`.
* The entity loading (and corresponding storage in the session) was completely pointless since we don't use the entity instances afterwards. So we had many pointless memory allocations.

Now:

* By not including a `SELECT` clause in the query, we're letting Hibernate use its default selection (which I think in this case is `h.*`).
* By calling `.project(LegumeItem.class)` we are still asking Hibernate to project query results to a `LegumeItem`, but since query results are just tuples of `id`, `name`, `description` we are now asking Hibernate to call `new LegumeItem(id, name, description)`.
* Thus we are skipping the entity loading entirely, along with a significant number of allocations.

Note that the first scenario would normally have triggered an exception along the lines of "cannot project query result type `Legume` to `LegumeItem`, missing constructor in `LegumeItem`", which would hopefully have given a hint that the query was not doing what we intended. But since we did declare a `LegumeItem(Legume)` constructor, it just worked...